### PR TITLE
config: create kubernetes manifests

### DIFF
--- a/python/src/manifests/auth-deploy.yaml
+++ b/python/src/manifests/auth-deploy.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth
+  labels:
+    app: auth
+
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: auth
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 3
+  template:
+    metadata:
+      labels:
+        app: auth
+    spec:
+      containers:
+        - name: auth
+          image: nischal2015/auth
+          ports:
+            - containerPort: 5000
+          envFrom:
+            - configMapRef:
+                name: auth-configmap
+            - secretRef:
+                name: auth-secret

--- a/python/src/manifests/configmap.yaml
+++ b/python/src/manifests/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: auth-configmap
+data:
+  MYSQL_HOST: host.minikube.internal
+  MYSQL_USER: auth_user
+  MYSQL_DB: auth
+  MYSQL_PORT: '3306'

--- a/python/src/manifests/secret.yaml
+++ b/python/src/manifests/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auth-secret
+stringData:
+  MYSQL_PASSWORD: Auth123
+  JWT_SECRET: sarcasm
+type: Opaque

--- a/python/src/manifests/service.yaml
+++ b/python/src/manifests/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth
+spec:
+  selector:
+    app: auth
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: 5000
+      protocol: TCP


### PR DESCRIPTION
The manifests are created using the kubernetes python client. The manifests are created to handle the kubernetes deployment of the auth service.